### PR TITLE
Propagate errors from Rust to Go

### DIFF
--- a/examples/numbersystem/numbers_test.go
+++ b/examples/numbersystem/numbers_test.go
@@ -42,7 +42,7 @@ func TestFixedExecutions(t *testing.T) {
 }
 
 func TestModelBased(t *testing.T) {
-	jsonTraces, err := core.GenerateJSONTracesFromTLATests("NumbersTest1.tla", "Numbers.cfg")
+	jsonTraces, err := core.GenerateJSONTracesFromTLATests("NumbersTest.tla", "Numbers.cfg")
 	if err != nil {
 		t.Error(err)
 	}

--- a/examples/numbersystem/numbers_test.go
+++ b/examples/numbersystem/numbers_test.go
@@ -42,7 +42,10 @@ func TestFixedExecutions(t *testing.T) {
 }
 
 func TestModelBased(t *testing.T) {
-	jsonTraces := core.GenerateJSONTracesFromTLATests("NumbersTest.tla", "Numbers.cfg")
+	jsonTraces, err := core.GenerateJSONTracesFromTLATests("NumbersTest1.tla", "Numbers.cfg")
+	if err != nil {
+		t.Error(err)
+	}
 	var tests map[string][][]Step
 	json.Unmarshal([]byte(jsonTraces), &tests)
 	for name, testRuns := range tests {

--- a/pkg/core/steprunner_test.go
+++ b/pkg/core/steprunner_test.go
@@ -1,0 +1,10 @@
+package core
+
+import "testing"
+
+func TestModelBased(t *testing.T) {
+	_, err := GenerateJSONTracesFromTLATests("doesnotexist", "doesnotexist")
+	if err == nil {
+		t.Error("Modelator should have returned error.")
+	}
+}

--- a/third_party/mbt/Cargo.toml
+++ b/third_party/mbt/Cargo.toml
@@ -11,5 +11,6 @@ authors = [
 crate-type = ["staticlib"]
 
 [dependencies]
+anyhow = "1.0.45"
 modelator = { git = "https://github.com/informalsystems/modelator" }
 serde_json = "1.0.68"

--- a/third_party/mbt/src/lib.h
+++ b/third_party/mbt/src/lib.h
@@ -1,2 +1,7 @@
-char *generate_json_traces_from_tla_tests_rs(char *tla_tests_file_path_c,
-                                             char *tla_config_file_path_c);
+typedef struct CResult {
+  char *json;
+  char *error;
+} CResult;
+
+struct CResult generate_json_traces_from_tla_tests_rs(char *tla_tests_file_path_c,
+                                                      char *tla_config_file_path_c);

--- a/third_party/mbt/src/lib.rs
+++ b/third_party/mbt/src/lib.rs
@@ -5,37 +5,47 @@ use std::os::raw::c_char;
 pub fn generate_json_traces_from_tla_tests(
     tla_tests_file_path: &str,
     tla_config_file_path: &str,
-) -> String {
+) -> Result<String, anyhow::Error> {
     let runtime = modelator::ModelatorRuntime::default();
-    let trace_results = runtime
-        .traces(tla_tests_file_path, tla_config_file_path)
-        .unwrap();
+    let trace_results = runtime.traces(tla_tests_file_path, tla_config_file_path)?;
     let trace_results = trace_results
         .into_iter()
-        .map(|(testname, traces)| {
-            let traces = traces.unwrap();
-            (
+        .map::<Result<_, anyhow::Error>, _>(|(testname, traces)| {
+            let traces = traces?;
+            Ok((
                 testname,
                 traces
                     .into_iter()
                     .map(|trace| trace.into_iter().collect::<Vec<_>>())
                     .collect::<Vec<_>>(),
-            )
+            ))
         })
-        .collect::<BTreeMap<_, _>>();
-    serde_json::to_string_pretty(&trace_results).unwrap()
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    Ok(serde_json::to_string_pretty(&trace_results)?)
+}
+
+#[repr(C)]
+pub struct CResult {
+    json: *mut c_char,
+    error: *mut c_char,
 }
 
 #[no_mangle]
 pub extern "C" fn generate_json_traces_from_tla_tests_rs(
     tla_tests_file_path_c: *mut c_char,
     tla_config_file_path_c: *mut c_char,
-) -> *mut c_char {
+) -> CResult {
     let tla_tests_file_path = unsafe { CString::from_raw(tla_tests_file_path_c) };
     let tla_config_file_path = unsafe { CString::from_raw(tla_config_file_path_c) };
-    let json_string = generate_json_traces_from_tla_tests(
+    let (json_string, error_string) = match generate_json_traces_from_tla_tests(
         tla_tests_file_path.to_str().unwrap(),
         tla_config_file_path.to_str().unwrap(),
-    );
-    CString::new(json_string).unwrap().into_raw()
+    ) {
+        Ok(json) => (json, String::new()),
+        Err(error) => (String::new(), format!("{:?}", error)),
+    };
+    CResult {
+        json: CString::new(json_string).unwrap().into_raw(),
+        error: CString::new(error_string).unwrap().into_raw(),
+    }
 }


### PR DESCRIPTION
addresses #1

Current commit adds a crude way to propagate errors from Rust to Go.

It uses `anyhow::Error` and converts all errors to string for FFI. 